### PR TITLE
fix: use nullable domains array to express no-change intent

### DIFF
--- a/adminclient/client.go
+++ b/adminclient/client.go
@@ -84,7 +84,7 @@ type IdentityProviderRequest struct {
 
 	Type string `json:"type,omitempty"`
 
-	Domains          []string         `json:"domains,omitempty"`
+	Domains          *[]string        `json:"domains,omitempty"`
 	MetadataXML      string           `json:"metadata_xml,omitempty"`
 	MetadataURL      string           `json:"metadata_url,omitempty"`
 	AttributeMapping AttributeMapping `json:"attribute_mapping,omitempty"`

--- a/gotrue/provider.go
+++ b/gotrue/provider.go
@@ -90,9 +90,13 @@ func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("domains") {
+		domains := make([]string, 0, 10)
+
 		for _, domain := range d.Get("domains").(*schema.Set).List() {
-			template.Domains = append(template.Domains, domain.(string))
+			domains = append(domains, domain.(string))
 		}
+
+		template.Domains = &domains
 	}
 
 	if d.HasChange("attribute_mapping") {
@@ -143,7 +147,7 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 			domains = append(domains, domain.(string))
 		}
 
-		template.Domains = domains
+		template.Domains = &domains
 	}
 
 	if keys, ok := d.GetOk("attribute_mapping"); ok && keys.(string) != "" {


### PR DESCRIPTION
There's a difference between not sending the `domains` parameter (which means no-change) and sending an empty array (which means remove all). This was not captured with the previous encoding of the `IdentityProviderRequest` struct.